### PR TITLE
fix: permissions for view

### DIFF
--- a/drizzle/0000_typical_nehzno.sql
+++ b/drizzle/0000_typical_nehzno.sql
@@ -106,41 +106,29 @@ EXCEPTION
  WHEN duplicate_object THEN null;
 END $$;
 --> statement-breakpoint
-CREATE POLICY "crud-authenticated-policy-insert" ON "chat_messages" AS PERMISSIVE FOR INSERT TO "authenticated";--> statement-breakpoint
-CREATE POLICY "crud-authenticated-policy-update" ON "chat_messages" AS PERMISSIVE FOR UPDATE TO "authenticated";--> statement-breakpoint
-CREATE POLICY "crud-authenticated-policy-delete" ON "chat_messages" AS PERMISSIVE FOR DELETE TO "authenticated";--> statement-breakpoint
+CREATE VIEW "public"."my_chats_participants" AS (select distinct "chatId", "userId" from "chat_participants" where "chat_participants"."chatId" in (select "chatId" from "chat_participants" where "chat_participants"."userId" = auth.user_id()));--> statement-breakpoint
 CREATE POLICY "crud-authenticated-policy-select" ON "chat_messages" AS PERMISSIVE FOR SELECT TO "authenticated" USING (((select auth.user_id()) in (select user_id from my_chats_participants where chat_id = "chat_messages"."chatId")));--> statement-breakpoint
 CREATE POLICY "chats-policy-insert" ON "chat_messages" AS PERMISSIVE FOR INSERT TO "authenticated" WITH CHECK (((select auth.user_id()) = "chat_messages"."sender" and (select auth.user_id()) in (select user_id from my_chats_participants where chat_id = "chat_messages"."chatId")));--> statement-breakpoint
+CREATE POLICY "crud-authenticated-policy-select" ON "chat_participants" AS PERMISSIVE FOR SELECT TO "authenticated" USING (false);--> statement-breakpoint
 CREATE POLICY "crud-authenticated-policy-insert" ON "chat_participants" AS PERMISSIVE FOR INSERT TO "authenticated" WITH CHECK ((select auth.user_id() = (select owner_id from chats where id = "chat_participants"."chatId")));--> statement-breakpoint
 CREATE POLICY "crud-authenticated-policy-update" ON "chat_participants" AS PERMISSIVE FOR UPDATE TO "authenticated" USING ((select auth.user_id() = (select owner_id from chats where id = "chat_participants"."chatId"))) WITH CHECK ((select auth.user_id() = (select owner_id from chats where id = "chat_participants"."chatId")));--> statement-breakpoint
 CREATE POLICY "crud-authenticated-policy-delete" ON "chat_participants" AS PERMISSIVE FOR DELETE TO "authenticated" USING ((select auth.user_id() = (select owner_id from chats where id = "chat_participants"."chatId")));--> statement-breakpoint
-CREATE POLICY "crud-authenticated-policy-select" ON "chat_participants" AS PERMISSIVE FOR SELECT TO "authenticated" USING (false);--> statement-breakpoint
+CREATE POLICY "crud-authenticated-policy-select" ON "chats" AS PERMISSIVE FOR SELECT TO "authenticated" USING (((select auth.user_id()) = "chats"."ownerId" or (select auth.user_id()) in (select user_id from MY_CHATS_PARTICIPANTS where chat_id = "chats"."id")));--> statement-breakpoint
 CREATE POLICY "crud-authenticated-policy-insert" ON "chats" AS PERMISSIVE FOR INSERT TO "authenticated" WITH CHECK ((select auth.user_id() = "chats"."ownerId"));--> statement-breakpoint
 CREATE POLICY "crud-authenticated-policy-update" ON "chats" AS PERMISSIVE FOR UPDATE TO "authenticated" USING ((select auth.user_id() = "chats"."ownerId")) WITH CHECK ((select auth.user_id() = "chats"."ownerId"));--> statement-breakpoint
 CREATE POLICY "crud-authenticated-policy-delete" ON "chats" AS PERMISSIVE FOR DELETE TO "authenticated" USING ((select auth.user_id() = "chats"."ownerId"));--> statement-breakpoint
-CREATE POLICY "crud-authenticated-policy-select" ON "chats" AS PERMISSIVE FOR SELECT TO "authenticated" USING (((select auth.user_id()) = "chats"."ownerId" or (select auth.user_id()) in (select user_id from MY_CHATS_PARTICIPANTS where chat_id = "chats"."id")));--> statement-breakpoint
-CREATE POLICY "crud-anonymous-policy-insert" ON "comments" AS PERMISSIVE FOR INSERT TO "anonymous";--> statement-breakpoint
-CREATE POLICY "crud-anonymous-policy-update" ON "comments" AS PERMISSIVE FOR UPDATE TO "anonymous";--> statement-breakpoint
-CREATE POLICY "crud-anonymous-policy-delete" ON "comments" AS PERMISSIVE FOR DELETE TO "anonymous";--> statement-breakpoint
 CREATE POLICY "crud-anonymous-policy-select" ON "comments" AS PERMISSIVE FOR SELECT TO "anonymous" USING (true);--> statement-breakpoint
+CREATE POLICY "crud-authenticated-policy-select" ON "comments" AS PERMISSIVE FOR SELECT TO "authenticated" USING (true);--> statement-breakpoint
 CREATE POLICY "crud-authenticated-policy-insert" ON "comments" AS PERMISSIVE FOR INSERT TO "authenticated" WITH CHECK ((select auth.user_id() = "comments"."userId"));--> statement-breakpoint
 CREATE POLICY "crud-authenticated-policy-update" ON "comments" AS PERMISSIVE FOR UPDATE TO "authenticated" USING ((select auth.user_id() = "comments"."userId")) WITH CHECK ((select auth.user_id() = "comments"."userId"));--> statement-breakpoint
 CREATE POLICY "crud-authenticated-policy-delete" ON "comments" AS PERMISSIVE FOR DELETE TO "authenticated" USING ((select auth.user_id() = "comments"."userId"));--> statement-breakpoint
-CREATE POLICY "crud-authenticated-policy-select" ON "comments" AS PERMISSIVE FOR SELECT TO "authenticated" USING (true);--> statement-breakpoint
-CREATE POLICY "crud-anonymous-policy-insert" ON "posts" AS PERMISSIVE FOR INSERT TO "anonymous";--> statement-breakpoint
-CREATE POLICY "crud-anonymous-policy-update" ON "posts" AS PERMISSIVE FOR UPDATE TO "anonymous";--> statement-breakpoint
-CREATE POLICY "crud-anonymous-policy-delete" ON "posts" AS PERMISSIVE FOR DELETE TO "anonymous";--> statement-breakpoint
 CREATE POLICY "crud-anonymous-policy-select" ON "posts" AS PERMISSIVE FOR SELECT TO "anonymous" USING (true);--> statement-breakpoint
+CREATE POLICY "crud-authenticated-policy-select" ON "posts" AS PERMISSIVE FOR SELECT TO "authenticated" USING (true);--> statement-breakpoint
 CREATE POLICY "crud-authenticated-policy-insert" ON "posts" AS PERMISSIVE FOR INSERT TO "authenticated" WITH CHECK ((select auth.user_id() = "posts"."userId"));--> statement-breakpoint
 CREATE POLICY "crud-authenticated-policy-update" ON "posts" AS PERMISSIVE FOR UPDATE TO "authenticated" USING ((select auth.user_id() = "posts"."userId")) WITH CHECK ((select auth.user_id() = "posts"."userId"));--> statement-breakpoint
 CREATE POLICY "crud-authenticated-policy-delete" ON "posts" AS PERMISSIVE FOR DELETE TO "authenticated" USING ((select auth.user_id() = "posts"."userId"));--> statement-breakpoint
-CREATE POLICY "crud-authenticated-policy-select" ON "posts" AS PERMISSIVE FOR SELECT TO "authenticated" USING (true);--> statement-breakpoint
-CREATE POLICY "crud-anonymous-policy-insert" ON "user_profiles" AS PERMISSIVE FOR INSERT TO "anonymous";--> statement-breakpoint
-CREATE POLICY "crud-anonymous-policy-update" ON "user_profiles" AS PERMISSIVE FOR UPDATE TO "anonymous";--> statement-breakpoint
-CREATE POLICY "crud-anonymous-policy-delete" ON "user_profiles" AS PERMISSIVE FOR DELETE TO "anonymous";--> statement-breakpoint
 CREATE POLICY "crud-anonymous-policy-select" ON "user_profiles" AS PERMISSIVE FOR SELECT TO "anonymous" USING (true);--> statement-breakpoint
+CREATE POLICY "crud-authenticated-policy-select" ON "user_profiles" AS PERMISSIVE FOR SELECT TO "authenticated" USING (true);--> statement-breakpoint
 CREATE POLICY "crud-authenticated-policy-insert" ON "user_profiles" AS PERMISSIVE FOR INSERT TO "authenticated" WITH CHECK ((select auth.user_id() = "user_profiles"."userId"));--> statement-breakpoint
 CREATE POLICY "crud-authenticated-policy-update" ON "user_profiles" AS PERMISSIVE FOR UPDATE TO "authenticated" USING ((select auth.user_id() = "user_profiles"."userId")) WITH CHECK ((select auth.user_id() = "user_profiles"."userId"));--> statement-breakpoint
-CREATE POLICY "crud-authenticated-policy-delete" ON "user_profiles" AS PERMISSIVE FOR DELETE TO "authenticated" USING ((select auth.user_id() = "user_profiles"."userId"));--> statement-breakpoint
-CREATE POLICY "crud-authenticated-policy-select" ON "user_profiles" AS PERMISSIVE FOR SELECT TO "authenticated" USING (true);--> statement-breakpoint
-CREATE VIEW "public"."my_chats_participants" AS (select "chatId", "userId" from "chat_participants" where "chat_participants"."chatId" in (select "chatId" from "chat_participants" where "chat_participants"."userId" = auth.user_id()));
+CREATE POLICY "crud-authenticated-policy-delete" ON "user_profiles" AS PERMISSIVE FOR DELETE TO "authenticated" USING ((select auth.user_id() = "user_profiles"."userId"));

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "fa1872a9-5fc3-4368-b19b-bf4557f31fc1",
+  "id": "9e320983-4ec8-461d-b994-206963eb3f20",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
@@ -39,12 +39,8 @@
           "name": "chat_messages_chatId_chats_id_fk",
           "tableFrom": "chat_messages",
           "tableTo": "chats",
-          "columnsFrom": [
-            "chatId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -52,12 +48,8 @@
           "name": "chat_messages_sender_users_userId_fk",
           "tableFrom": "chat_messages",
           "tableTo": "users",
-          "columnsFrom": [
-            "sender"
-          ],
-          "columnsTo": [
-            "userId"
-          ],
+          "columnsFrom": ["sender"],
+          "columnsTo": ["userId"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -65,46 +57,18 @@
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {
-        "crud-authenticated-policy-insert": {
-          "name": "crud-authenticated-policy-insert",
-          "as": "PERMISSIVE",
-          "for": "INSERT",
-          "to": [
-            "authenticated"
-          ]
-        },
-        "crud-authenticated-policy-update": {
-          "name": "crud-authenticated-policy-update",
-          "as": "PERMISSIVE",
-          "for": "UPDATE",
-          "to": [
-            "authenticated"
-          ]
-        },
-        "crud-authenticated-policy-delete": {
-          "name": "crud-authenticated-policy-delete",
-          "as": "PERMISSIVE",
-          "for": "DELETE",
-          "to": [
-            "authenticated"
-          ]
-        },
         "crud-authenticated-policy-select": {
           "name": "crud-authenticated-policy-select",
           "as": "PERMISSIVE",
           "for": "SELECT",
-          "to": [
-            "authenticated"
-          ],
+          "to": ["authenticated"],
           "using": "((select auth.user_id()) in (select user_id from my_chats_participants where chat_id = \"chat_messages\".\"chatId\"))"
         },
         "chats-policy-insert": {
           "name": "chats-policy-insert",
           "as": "PERMISSIVE",
           "for": "INSERT",
-          "to": [
-            "authenticated"
-          ],
+          "to": ["authenticated"],
           "withCheck": "((select auth.user_id()) = \"chat_messages\".\"sender\" and (select auth.user_id()) in (select user_id from my_chats_participants where chat_id = \"chat_messages\".\"chatId\"))"
         }
       },
@@ -134,12 +98,8 @@
           "name": "chat_participants_chatId_chats_id_fk",
           "tableFrom": "chat_participants",
           "tableTo": "chats",
-          "columnsFrom": [
-            "chatId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -147,12 +107,8 @@
           "name": "chat_participants_userId_users_userId_fk",
           "tableFrom": "chat_participants",
           "tableTo": "users",
-          "columnsFrom": [
-            "userId"
-          ],
-          "columnsTo": [
-            "userId"
-          ],
+          "columnsFrom": ["userId"],
+          "columnsTo": ["userId"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -160,30 +116,30 @@
       "compositePrimaryKeys": {
         "chat_participants_chatId_userId_pk": {
           "name": "chat_participants_chatId_userId_pk",
-          "columns": [
-            "chatId",
-            "userId"
-          ]
+          "columns": ["chatId", "userId"]
         }
       },
       "uniqueConstraints": {},
       "policies": {
+        "crud-authenticated-policy-select": {
+          "name": "crud-authenticated-policy-select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["authenticated"],
+          "using": "false"
+        },
         "crud-authenticated-policy-insert": {
           "name": "crud-authenticated-policy-insert",
           "as": "PERMISSIVE",
           "for": "INSERT",
-          "to": [
-            "authenticated"
-          ],
+          "to": ["authenticated"],
           "withCheck": "(select auth.user_id() = (select owner_id from chats where id = \"chat_participants\".\"chatId\"))"
         },
         "crud-authenticated-policy-update": {
           "name": "crud-authenticated-policy-update",
           "as": "PERMISSIVE",
           "for": "UPDATE",
-          "to": [
-            "authenticated"
-          ],
+          "to": ["authenticated"],
           "using": "(select auth.user_id() = (select owner_id from chats where id = \"chat_participants\".\"chatId\"))",
           "withCheck": "(select auth.user_id() = (select owner_id from chats where id = \"chat_participants\".\"chatId\"))"
         },
@@ -191,19 +147,8 @@
           "name": "crud-authenticated-policy-delete",
           "as": "PERMISSIVE",
           "for": "DELETE",
-          "to": [
-            "authenticated"
-          ],
+          "to": ["authenticated"],
           "using": "(select auth.user_id() = (select owner_id from chats where id = \"chat_participants\".\"chatId\"))"
-        },
-        "crud-authenticated-policy-select": {
-          "name": "crud-authenticated-policy-select",
-          "as": "PERMISSIVE",
-          "for": "SELECT",
-          "to": [
-            "authenticated"
-          ],
-          "using": "false"
         }
       },
       "checkConstraints": {},
@@ -238,12 +183,8 @@
           "name": "chats_ownerId_users_userId_fk",
           "tableFrom": "chats",
           "tableTo": "users",
-          "columnsFrom": [
-            "ownerId"
-          ],
-          "columnsTo": [
-            "userId"
-          ],
+          "columnsFrom": ["ownerId"],
+          "columnsTo": ["userId"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -251,22 +192,25 @@
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {
+        "crud-authenticated-policy-select": {
+          "name": "crud-authenticated-policy-select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["authenticated"],
+          "using": "((select auth.user_id()) = \"chats\".\"ownerId\" or (select auth.user_id()) in (select user_id from MY_CHATS_PARTICIPANTS where chat_id = \"chats\".\"id\"))"
+        },
         "crud-authenticated-policy-insert": {
           "name": "crud-authenticated-policy-insert",
           "as": "PERMISSIVE",
           "for": "INSERT",
-          "to": [
-            "authenticated"
-          ],
+          "to": ["authenticated"],
           "withCheck": "(select auth.user_id() = \"chats\".\"ownerId\")"
         },
         "crud-authenticated-policy-update": {
           "name": "crud-authenticated-policy-update",
           "as": "PERMISSIVE",
           "for": "UPDATE",
-          "to": [
-            "authenticated"
-          ],
+          "to": ["authenticated"],
           "using": "(select auth.user_id() = \"chats\".\"ownerId\")",
           "withCheck": "(select auth.user_id() = \"chats\".\"ownerId\")"
         },
@@ -274,19 +218,8 @@
           "name": "crud-authenticated-policy-delete",
           "as": "PERMISSIVE",
           "for": "DELETE",
-          "to": [
-            "authenticated"
-          ],
+          "to": ["authenticated"],
           "using": "(select auth.user_id() = \"chats\".\"ownerId\")"
-        },
-        "crud-authenticated-policy-select": {
-          "name": "crud-authenticated-policy-select",
-          "as": "PERMISSIVE",
-          "for": "SELECT",
-          "to": [
-            "authenticated"
-          ],
-          "using": "((select auth.user_id()) = \"chats\".\"ownerId\" or (select auth.user_id()) in (select user_id from MY_CHATS_PARTICIPANTS where chat_id = \"chats\".\"id\"))"
         }
       },
       "checkConstraints": {},
@@ -327,12 +260,8 @@
           "name": "comments_postId_posts_id_fk",
           "tableFrom": "comments",
           "tableTo": "posts",
-          "columnsFrom": [
-            "postId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["postId"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -340,12 +269,8 @@
           "name": "comments_userId_users_userId_fk",
           "tableFrom": "comments",
           "tableTo": "users",
-          "columnsFrom": [
-            "userId"
-          ],
-          "columnsTo": [
-            "userId"
-          ],
+          "columnsFrom": ["userId"],
+          "columnsTo": ["userId"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -353,55 +278,32 @@
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {
-        "crud-anonymous-policy-insert": {
-          "name": "crud-anonymous-policy-insert",
-          "as": "PERMISSIVE",
-          "for": "INSERT",
-          "to": [
-            "anonymous"
-          ]
-        },
-        "crud-anonymous-policy-update": {
-          "name": "crud-anonymous-policy-update",
-          "as": "PERMISSIVE",
-          "for": "UPDATE",
-          "to": [
-            "anonymous"
-          ]
-        },
-        "crud-anonymous-policy-delete": {
-          "name": "crud-anonymous-policy-delete",
-          "as": "PERMISSIVE",
-          "for": "DELETE",
-          "to": [
-            "anonymous"
-          ]
-        },
         "crud-anonymous-policy-select": {
           "name": "crud-anonymous-policy-select",
           "as": "PERMISSIVE",
           "for": "SELECT",
-          "to": [
-            "anonymous"
-          ],
+          "to": ["anonymous"],
+          "using": "true"
+        },
+        "crud-authenticated-policy-select": {
+          "name": "crud-authenticated-policy-select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["authenticated"],
           "using": "true"
         },
         "crud-authenticated-policy-insert": {
           "name": "crud-authenticated-policy-insert",
           "as": "PERMISSIVE",
           "for": "INSERT",
-          "to": [
-            "authenticated"
-          ],
+          "to": ["authenticated"],
           "withCheck": "(select auth.user_id() = \"comments\".\"userId\")"
         },
         "crud-authenticated-policy-update": {
           "name": "crud-authenticated-policy-update",
           "as": "PERMISSIVE",
           "for": "UPDATE",
-          "to": [
-            "authenticated"
-          ],
+          "to": ["authenticated"],
           "using": "(select auth.user_id() = \"comments\".\"userId\")",
           "withCheck": "(select auth.user_id() = \"comments\".\"userId\")"
         },
@@ -409,19 +311,8 @@
           "name": "crud-authenticated-policy-delete",
           "as": "PERMISSIVE",
           "for": "DELETE",
-          "to": [
-            "authenticated"
-          ],
+          "to": ["authenticated"],
           "using": "(select auth.user_id() = \"comments\".\"userId\")"
-        },
-        "crud-authenticated-policy-select": {
-          "name": "crud-authenticated-policy-select",
-          "as": "PERMISSIVE",
-          "for": "SELECT",
-          "to": [
-            "authenticated"
-          ],
-          "using": "true"
         }
       },
       "checkConstraints": {},
@@ -462,12 +353,8 @@
           "name": "posts_userId_users_userId_fk",
           "tableFrom": "posts",
           "tableTo": "users",
-          "columnsFrom": [
-            "userId"
-          ],
-          "columnsTo": [
-            "userId"
-          ],
+          "columnsFrom": ["userId"],
+          "columnsTo": ["userId"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -475,55 +362,32 @@
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {
-        "crud-anonymous-policy-insert": {
-          "name": "crud-anonymous-policy-insert",
-          "as": "PERMISSIVE",
-          "for": "INSERT",
-          "to": [
-            "anonymous"
-          ]
-        },
-        "crud-anonymous-policy-update": {
-          "name": "crud-anonymous-policy-update",
-          "as": "PERMISSIVE",
-          "for": "UPDATE",
-          "to": [
-            "anonymous"
-          ]
-        },
-        "crud-anonymous-policy-delete": {
-          "name": "crud-anonymous-policy-delete",
-          "as": "PERMISSIVE",
-          "for": "DELETE",
-          "to": [
-            "anonymous"
-          ]
-        },
         "crud-anonymous-policy-select": {
           "name": "crud-anonymous-policy-select",
           "as": "PERMISSIVE",
           "for": "SELECT",
-          "to": [
-            "anonymous"
-          ],
+          "to": ["anonymous"],
+          "using": "true"
+        },
+        "crud-authenticated-policy-select": {
+          "name": "crud-authenticated-policy-select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["authenticated"],
           "using": "true"
         },
         "crud-authenticated-policy-insert": {
           "name": "crud-authenticated-policy-insert",
           "as": "PERMISSIVE",
           "for": "INSERT",
-          "to": [
-            "authenticated"
-          ],
+          "to": ["authenticated"],
           "withCheck": "(select auth.user_id() = \"posts\".\"userId\")"
         },
         "crud-authenticated-policy-update": {
           "name": "crud-authenticated-policy-update",
           "as": "PERMISSIVE",
           "for": "UPDATE",
-          "to": [
-            "authenticated"
-          ],
+          "to": ["authenticated"],
           "using": "(select auth.user_id() = \"posts\".\"userId\")",
           "withCheck": "(select auth.user_id() = \"posts\".\"userId\")"
         },
@@ -531,19 +395,8 @@
           "name": "crud-authenticated-policy-delete",
           "as": "PERMISSIVE",
           "for": "DELETE",
-          "to": [
-            "authenticated"
-          ],
+          "to": ["authenticated"],
           "using": "(select auth.user_id() = \"posts\".\"userId\")"
-        },
-        "crud-authenticated-policy-select": {
-          "name": "crud-authenticated-policy-select",
-          "as": "PERMISSIVE",
-          "for": "SELECT",
-          "to": [
-            "authenticated"
-          ],
-          "using": "true"
         }
       },
       "checkConstraints": {},
@@ -572,12 +425,8 @@
           "name": "user_profiles_userId_users_userId_fk",
           "tableFrom": "user_profiles",
           "tableTo": "users",
-          "columnsFrom": [
-            "userId"
-          ],
-          "columnsTo": [
-            "userId"
-          ],
+          "columnsFrom": ["userId"],
+          "columnsTo": ["userId"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -587,61 +436,36 @@
         "user_profiles_userId_unique": {
           "name": "user_profiles_userId_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "userId"
-          ]
+          "columns": ["userId"]
         }
       },
       "policies": {
-        "crud-anonymous-policy-insert": {
-          "name": "crud-anonymous-policy-insert",
-          "as": "PERMISSIVE",
-          "for": "INSERT",
-          "to": [
-            "anonymous"
-          ]
-        },
-        "crud-anonymous-policy-update": {
-          "name": "crud-anonymous-policy-update",
-          "as": "PERMISSIVE",
-          "for": "UPDATE",
-          "to": [
-            "anonymous"
-          ]
-        },
-        "crud-anonymous-policy-delete": {
-          "name": "crud-anonymous-policy-delete",
-          "as": "PERMISSIVE",
-          "for": "DELETE",
-          "to": [
-            "anonymous"
-          ]
-        },
         "crud-anonymous-policy-select": {
           "name": "crud-anonymous-policy-select",
           "as": "PERMISSIVE",
           "for": "SELECT",
-          "to": [
-            "anonymous"
-          ],
+          "to": ["anonymous"],
+          "using": "true"
+        },
+        "crud-authenticated-policy-select": {
+          "name": "crud-authenticated-policy-select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": ["authenticated"],
           "using": "true"
         },
         "crud-authenticated-policy-insert": {
           "name": "crud-authenticated-policy-insert",
           "as": "PERMISSIVE",
           "for": "INSERT",
-          "to": [
-            "authenticated"
-          ],
+          "to": ["authenticated"],
           "withCheck": "(select auth.user_id() = \"user_profiles\".\"userId\")"
         },
         "crud-authenticated-policy-update": {
           "name": "crud-authenticated-policy-update",
           "as": "PERMISSIVE",
           "for": "UPDATE",
-          "to": [
-            "authenticated"
-          ],
+          "to": ["authenticated"],
           "using": "(select auth.user_id() = \"user_profiles\".\"userId\")",
           "withCheck": "(select auth.user_id() = \"user_profiles\".\"userId\")"
         },
@@ -649,19 +473,8 @@
           "name": "crud-authenticated-policy-delete",
           "as": "PERMISSIVE",
           "for": "DELETE",
-          "to": [
-            "authenticated"
-          ],
+          "to": ["authenticated"],
           "using": "(select auth.user_id() = \"user_profiles\".\"userId\")"
-        },
-        "crud-authenticated-policy-select": {
-          "name": "crud-authenticated-policy-select",
-          "as": "PERMISSIVE",
-          "for": "SELECT",
-          "to": [
-            "authenticated"
-          ],
-          "using": "true"
         }
       },
       "checkConstraints": {},
@@ -705,9 +518,7 @@
         "users_email_unique": {
           "name": "users_email_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "email"
-          ]
+          "columns": ["email"]
         }
       },
       "policies": {},
@@ -719,6 +530,7 @@
   "schemas": {},
   "sequences": {},
   "roles": {},
+  "policies": {},
   "views": {
     "public.my_chats_participants": {
       "columns": {
@@ -735,7 +547,7 @@
           "notNull": false
         }
       },
-      "definition": "select \"chatId\", \"userId\" from \"chat_participants\" where \"chat_participants\".\"chatId\" in (select \"chatId\" from \"chat_participants\" where \"chat_participants\".\"userId\" = auth.user_id())",
+      "definition": "select distinct \"chatId\", \"userId\" from \"chat_participants\" where \"chat_participants\".\"chatId\" in (select \"chatId\" from \"chat_participants\" where \"chat_participants\".\"userId\" = auth.user_id())",
       "name": "my_chats_participants",
       "schema": "public",
       "isExisting": false,

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1730839004356,
-      "tag": "0000_useful_the_fallen",
+      "when": 1730983930285,
+      "tag": "0000_typical_nehzno",
       "breakpoints": true
     }
   ]


### PR DESCRIPTION
## Description

Unfortunately, our view wasn't fully secure, and in fact, anyone could go ahead and run `delete`, `update` and `create` on them, because it had the `db_owner` permissions by default.

**FIX**
- setting `securityInvoker: true` doesn't work because of the `read: false` in `chat_participants`, which will make this view return no rows:
  - setting `read: true` in `chat_participants` will make it so that you can read all rows, and that doesn't work also
  - setting any simple rule like `select auth.user_id() in (select user_id from my_chats_participants_view)` will, again, result in a recursion error
- setting `securityInvoker: false` (or omitting it) works for `read` since it's already filtering by the auth_id, in a sense, the view is its own RLS rule
  - however, having it this way will make the caller have the same permissions as `db_owner` for UPDATE/DELETE/CREATE, which is wrong
  - to fix this, we must somehow make the view **read-only**, and although Postgres doesn't offer an explicit way to do so, like some other DBs, it's quite easy to turn any view into "read-only" by breaking any of this subset of rules: https://www.postgresql.org/docs/current/sql-createview.html
  - so, we can go around this by simply selecting with `DISTINCT`, doing a join, or adding a `with` clause
  
 
 For this scenario, I think `distinct` is a good application and does the job, by turning this view into a `read-only` object.
 
 **NOTES**
 
 Bare in mind that this is a bit hacky, but it does seem to be the only way to do RLS + Drizzle for our current business rules, since `functions` are not yet supported by Drizzle.
 
 ## Test Plan
 
 I tested this in my dumb UI by trying to delete a user after the changes, and this is the result:
 
![image](https://github.com/user-attachments/assets/ab1fd87f-1502-48fa-aba7-4d11197eb389)
